### PR TITLE
Fix cert conflicts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.17
+version: 0.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/example_output.yaml
+++ b/example_output.yaml
@@ -194,8 +194,8 @@ metadata:
 spec:
   secretName: alternativedomain-com-tls
   dnsNames:
-  - "alternativedomain.com"
-  - "*.alternativedomain.com"
+    - "alternativedomain.com"
+    - "*.alternativedomain.com"
   issuerRef:
     name: wildcard-letsencrypt-prod
     kind: ClusterIssuer
@@ -209,8 +209,8 @@ metadata:
 spec:
   secretName: pennlabs-org-tls
   dnsNames:
-  - "pennlabs.org"
-  - "*.pennlabs.org"
+    - "pennlabs.org"
+    - "*.pennlabs.org"
   issuerRef:
     name: wildcard-letsencrypt-prod
     kind: ClusterIssuer

--- a/templates/certificates.yaml
+++ b/templates/certificates.yaml
@@ -18,8 +18,8 @@ metadata:
 spec:
   secretName: {{ $name }}-tls-{{ $release }}
   dnsNames:
-  - {{ $domain | quote }}
-  - {{ printf "*.%s" $domain | quote }}
+    - {{ $domain | quote }}
+    - {{ printf "*.%s" $domain | quote }}
   issuerRef:
     name: {{ .issuer_name }}
     kind: ClusterIssuer

--- a/templates/certificates.yaml
+++ b/templates/certificates.yaml
@@ -15,8 +15,6 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ $name }}
-  annotations:
-    "helm.sh/resource-policy": keep
 spec:
   secretName: {{ $name }}-tls-{{ $release }}
   dnsNames:

--- a/templates/certificates.yaml
+++ b/templates/certificates.yaml
@@ -9,15 +9,17 @@
 {{- range .ingress.hosts }}
 {{/* Regex to compute the apex domain */}}
 {{- $domain := regexFind "[\\w-]+\\.[\\w]+$" .host }}
+{{- $name := $domain | replace "." "-" }}
+{{- if not (lookup "cert-manager.io/v1alpha2" "Certificate" $releasens $name) }}
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
-  name: {{ $domain | replace "." "-" }}
+  name: {{ $name }}
   annotations:
     "helm.sh/resource-policy": keep
 spec:
-  secretName: {{ $domain | replace "." "-" }}-tls
+  secretName: {{ $name }}-tls
   dnsNames:
   - {{ $domain | quote }}
   - {{ printf "*.%s" $domain | quote }}
@@ -25,6 +27,7 @@ spec:
     name: {{ .issuer_name }}
     kind: ClusterIssuer
     group: cert-manager.io
+{{- end }}
 {{- end }}
 {{- end }}
 {{ end }}

--- a/templates/certificates.yaml
+++ b/templates/certificates.yaml
@@ -10,7 +10,6 @@
 {{/* Regex to compute the apex domain */}}
 {{- $domain := regexFind "[\\w-]+\\.[\\w]+$" .host }}
 {{- $name := $domain | replace "." "-" }}
-{{- if not (lookup "cert-manager.io/v1alpha2" "Certificate" $releasens $name) }}
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
@@ -19,7 +18,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
 spec:
-  secretName: {{ $name }}-tls
+  secretName: {{ $name }}-tls-{{ $release }}
   dnsNames:
   - {{ $domain | quote }}
   - {{ printf "*.%s" $domain | quote }}
@@ -27,7 +26,6 @@ spec:
     name: {{ .issuer_name }}
     kind: ClusterIssuer
     group: cert-manager.io
-{{- end }}
 {{- end }}
 {{- end }}
 {{ end }}

--- a/templates/certificates.yaml
+++ b/templates/certificates.yaml
@@ -14,9 +14,9 @@
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
-  name: {{ $name }}
+  name: {{ $name }}-{{ $release }}
 spec:
-  secretName: {{ $name }}-tls-{{ $release }}
+  secretName: {{ $name }}-tls
   dnsNames:
     - {{ $domain | quote }}
     - {{ printf "*.%s" $domain | quote }}


### PR DESCRIPTION
This PR adds a check so that helm doesn't try to override an existing Certificate. Without this check, helm will throw the following error when trying to install/upgrade a release: `Error: rendered manifests contain a resource that already exists.`