### PR TITLE
Default to rolling update

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.21
+version: 0.1.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -19,6 +19,11 @@ spec:
   selector:
     matchLabels:
       name: {{ $app_id | quote }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR adds a rolling update strategy with the following settings:
- You can have a max of 3 extra pods than what the replicas specify
- You can have a max of 0 unavailable